### PR TITLE
Remove debug output from numpy python binding

### DIFF
--- a/bindings/python/aleph.cc
+++ b/bindings/python/aleph.cc
@@ -293,7 +293,6 @@ void wrapPersistenceDiagram( py::module& m )
       // Callback that allows buffer to be freed if not used in python anymore
       py::capsule free_when_done(buffer, [](void *f) {
             DataType *buf = reinterpret_cast<DataType *>(f);
-            std::cerr << "freeing memory  allocated by aleph @ " << f << "\n";
             delete[] buf;
         });
 


### PR DESCRIPTION
The numpy array conversion of persistence diagrams creates a lot of debug output which clutters log files (should have removed it before pushing the original contribution).