### PR TITLE
Few steps closer for a complete Conan packaging, for issue #27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,23 @@ SET( BUILD_TOOLS
   "Build with tools"
 )
 
+SET( USE_CONAN
+  "ON"
+  CACHE
+  BOOL
+  "Use conan for downloading and installing dependencies"
+)
+
+IF( USE_CONAN )
+  # Bring conan generated dependencies
+  IF( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake )
+    INCLUDE( ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake )
+  ELSE()
+    MESSAGE( WARNING "The file conanbuildinfo.cmake does not exist, you have to run conan install first." )
+  ENDIF()
+  CONAN_BASIC_SETUP()
+ENDIF()
+
 ########################################################################
 # Additional packages
 ########################################################################
@@ -144,7 +161,13 @@ ENDIF()
 
 FIND_PACKAGE( PkgConfig )
 
-IF( PKG_CONFIG_FOUND )
+IF( USE_CONAN AND DEFINED CONAN_INCLUDE_DIRS_RAPIDJSON )
+  # RapidJSON is now available in the normal include path, under the
+  # prefix of RapidJSON.
+  INCLUDE_DIRECTORIES( SYSTEM ${CONAN_INCLUDE_DIRS_RAPIDJSON} )
+
+  SET( ALEPH_WITH_RAPID_JSON TRUE )
+ELSEIF( PKG_CONFIG_FOUND )
   PKG_SEARCH_MODULE( JSON RapidJSON )
 
   IF( JSON_FOUND )
@@ -154,10 +177,44 @@ IF( PKG_CONFIG_FOUND )
 
     SET( ALEPH_WITH_RAPID_JSON TRUE )
   ENDIF()
+ENDIF()
 
+IF( USE_CONAN AND DEFINED CONAN_INCLUDE_DIRS_RAPIDJSON )
+  MESSAGE( STATUS "RapidJSON has been found through Conan; use ALEPH_WITH_RAPID_JSON to toggle its usage" )
+
+  # RapidJSON is now available in the normal include path, under the
+  # prefix of RapidJSON.
+  INCLUDE_DIRECTORIES( SYSTEM ${CONAN_INCLUDE_DIRS_RAPIDJSON} )
+
+  SET( ALEPH_WITH_RAPID_JSON TRUE )
+ELSEIF( PKG_CONFIG_FOUND )
+  PKG_SEARCH_MODULE( JSON RapidJSON )
+
+  IF( JSON_FOUND )
+    MESSAGE( STATUS "RapidJSON has been found through PkgConifg; use ALEPH_WITH_RAPID_JSON to toggle its usage" )
+
+    # RapidJSON is now available in the normal include path, under the
+    # prefix of RapidJSON.
+    INCLUDE_DIRECTORIES( SYSTEM ${JSON_INCLUDE_DIRS} )
+
+    SET( ALEPH_WITH_RAPID_JSON TRUE )
+  ENDIF()
+ENDIF()
+
+IF( USE_CONAN AND DEFINED CONAN_INCLUDE_DIRS_EIGEN )
+  MESSAGE( STATUS "EIGEN has been found through Conan; use ALEPH_WITH_EIGEN to toggle its usage" )
+
+  # RapidJSON is now available in the normal include path, under the
+  # prefix of RapidJSON.
+  INCLUDE_DIRECTORIES( SYSTEM ${CONAN_INCLUDE_DIRS_EIGEN} )
+
+  SET( ALEPH_WITH_EIGEN TRUE )
+ELSEIF( PKG_CONFIG_FOUND )
   PKG_SEARCH_MODULE( EIGEN eigen3 )
 
   IF( EIGEN_FOUND )
+    MESSAGE( STATUS "EIGEN has been found through PkgConfig; use ALEPH_WITH_EIGEN to toggle its usage" )
+
     INCLUDE_DIRECTORIES( SYSTEM ${EIGEN_INCLUDE_DIRS} )
 
     SET( ALEPH_WITH_EIGEN TRUE )
@@ -166,8 +223,8 @@ ENDIF()
 
 # Not used here, but in subordinate directories, so it is nicer to
 # look for the package in a *single* location.
-FIND_PACKAGE(PythonInterp 3)
-FIND_PACKAGE(PythonLibs   3)
+FIND_PACKAGE( PythonInterp 3 )
+FIND_PACKAGE( PythonLibs 3 )
 
 FIND_PACKAGE( tinyxml2 )
 

--- a/cmake/Modules/Findtinyxml2.cmake
+++ b/cmake/Modules/Findtinyxml2.cmake
@@ -1,0 +1,62 @@
+# Module: Findtinyxml2.cmake
+# Author: Asem Alaa <asem.a.abdelaziz@ieee.org>
+#
+# CMake find module for tinyxml2 with Conan support.
+
+INCLUDE( FindPackageHandleStandardArgs )
+
+FIND_PATH( tinyxml2_INCLUDE_DIR
+  NAMES
+    tinyxml2.h
+  PATHS
+    ${CONAN_INCLUDE_DIRS_TINYXML2}
+)
+
+FIND_LIBRARY( tinyxml2_LIBRARY
+  NAMES
+    ${CONAN_LIBS_TINYXML2}
+  PATHS
+    ${CONAN_LIB_DIRS_TINYXML2}
+)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( tinyxml2 DEFAULT_MSG
+  tinyxml2_INCLUDE_DIR
+)
+
+IF( tinyxml2_FOUND )
+  SET( tinyxml2_INCLUDE_DIRS ${tinyxml2_INCLUDE_DIR} )
+  SET( tinyxml2_LIBRARIES ${tinyxml2_LIBRARY} )
+
+  # Due to an immature recipe file of tinyxml2, the generated tinyxml2 files are not exported from
+  # the build directory to the package directory. Issue reported here:
+  # https://github.com/nicolastagliani/conan-tinyxml2/issues/3
+  # So currenty, as a workaround, we will retrieve the tinyxml2Config.cmake file from the build directory!
+  get_filename_component( tinyxml2_CONFIG_PATH ${CONAN_TINYXML2_ROOT} DIRECTORY )
+  get_filename_component( tinyxml2_HASH ${CONAN_TINYXML2_ROOT} NAME )
+  get_filename_component( tinyxml2_CONFIG_PATH ${tinyxml2_CONFIG_PATH} DIRECTORY )
+  set( tinyxml2_CONFIG_PATH  ${tinyxml2_CONFIG_PATH}/build/${tinyxml2_HASH} )
+  set( tinyxml2_CONFIG_FILENAME tinyxml2Config.cmake )
+
+  find_file( tinyxml2_CONFIG_DIR
+      ${tinyxml2_CONFIG_FILENAME}
+    HINTS
+      ${tinyxml2_CONFIG_PATH}
+  )
+
+  IF( tinyxml2_CONFIG_DIR-NOTFOUND )
+    set( tinyxml2_CONFIG "" )
+  ELSE()
+    set( tinyxml2_CONFIG ${tinyxml2_CONFIG_DIR} )
+  ENDIF()
+
+  MARK_AS_ADVANCED(
+    tinyxml2_INCLUDE_DIR
+    tinyxml2_LIBRARY
+    tinyxml2_DIR
+    tinyxml2_CONFIG
+  )
+ELSE()
+  SET( tinyxml2_DIR "" CACHE STRING
+    "An optional hint to a tinyxml2 directory"
+  )
+ENDIF()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake, tools
+
+class AlephConan(ConanFile):
+    name = "Aleph"
+    version = "0.0.1"
+    license = "MIT"
+    url = "https://github.com/Submanifold/Aleph"
+    description = "A library for exploring persistent homology https://submanifold.github.io/Aleph/"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"enable_rapidjson" : [True, False], "enable_pybind" : [True, False], "enable_eigen" : [True, False], "enable_tinyxml2" : [True, False]}
+    default_options = "enable_rapidjson=False", "enable_pybind=False", "enable_pybind=False", "enable_eigen=False", "enable_tinyxml2=False" 
+    generators = "cmake"
+    exports_sources = ["Findtinyxml2.cmake"]
+
+    def requirements(self):
+        self.requires("boost/1.65.1@conan/stable")
+
+        if self.options.enable_rapidjson:
+            self.requires("rapidjson/1.1.0@bincrafters/stable")
+
+        if self.options.enable_pybind:
+            self.requires("pybind11/2.2.4@conan/stable")
+
+        if self.options.enable_eigen:
+            self.requires("eigen/3.3.5@conan/stable")
+
+        if self.options.enable_tinyxml2:
+            self.requires("tinyxml2/7.0.1@nicolastagliani/stable")
+
+    def package_info(self):
+        self.copy("Findtinyxml2.cmake", ".", ".")


### PR DESCRIPTION
* Added Conan file to automatically fetch the dependencies using their Conan recipes:
  1. `Boost`, with its components.
  1. `RapidJSON`
  1. `PyBind11`
  1. `Eigen3`
  1. `tinyxml2`
* The `FLANN` has no Conan recipe available yet. Could be made manually if it is significant and needed.

## Using Conan

```
mkdir build
cd build
conan install .. -o enable_rapidjson=True -o enable_eigen=True -o enable_tinyxml2=True -o enable_pybind=True --build missing
cmake ..
```

This will download and install all the optional dependencies except the `FLANN`. Also, any option in the Conan installation command can be omitted.

Conan in general is very promising, well documented, very active support, but not yet widely adopted since it is very new.